### PR TITLE
Adding middleware to set content type to JSON

### DIFF
--- a/api/router/middleware/content_type_json.go
+++ b/api/router/middleware/content_type_json.go
@@ -1,0 +1,10 @@
+package middleware
+
+import "net/http"
+
+func ContentTypeJson(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json;charset=utf8")
+		next.ServeHTTP(w, r)
+	})
+}

--- a/api/router/middleware/content_type_json_test.go
+++ b/api/router/middleware/content_type_json_test.go
@@ -1,0 +1,41 @@
+package middleware_test
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/mergeforces/mergeforces-service/api/router/middleware"
+)
+
+var (
+	expRespBody    = "{\"message\":\"Hello World!\"}"
+	expContentType = "application/json;charset=utf8"
+)
+
+func TestContentTypeJson(t *testing.T) {
+	r, _ := http.NewRequest("GET", "/", nil)
+	rr := httptest.NewRecorder()
+
+	middleware.ContentTypeJson(http.HandlerFunc(sampleHandlerFunc())).ServeHTTP(rr, r)
+	response := rr.Result()
+
+	if respBody := rr.Body.String(); respBody != expRespBody {
+		t.Errorf("Wrong response body:  got %v want %v ", respBody, expRespBody)
+	}
+
+	if status := response.StatusCode; status != http.StatusOK {
+		t.Errorf("Wrong status code: got %v want %v", status, http.StatusOK)
+	}
+
+	if contentType := response.Header.Get("Content-type"); contentType != expContentType {
+		t.Errorf("Wrong status code: got %v want %v", contentType, expContentType)
+	}
+}
+
+func sampleHandlerFunc() func(w http.ResponseWriter, r *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, expRespBody)
+	}
+}

--- a/api/router/router.go
+++ b/api/router/router.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/mergeforces/mergeforces-service/api/app"
 	"github.com/mergeforces/mergeforces-service/api/handler"
+	"github.com/mergeforces/mergeforces-service/api/router/middleware"
 )
 
 func New(app *app.App)  *chi.Mux {
@@ -14,11 +15,15 @@ func New(app *app.App)  *chi.Mux {
 	r.Get("/health/live", app.HandleLive)
 	r.Method("GET", "/health/ready", handler.NewHandler(app.HandleReady, l))
 
-	r.Method("GET", "/events", handler.NewHandler(app.HandleListEvents, l))
-	r.Method("POST", "/events", handler.NewHandler(app.HandleCreateEvent, l))
-	r.Method("GET", "/events/{id}", handler.NewHandler(app.HandleReadEvent, l))
-	r.Method("PUT", "/events/{id}", handler.NewHandler(app.HandleUpdateEvent, l))
-	r.Method("DELETE", "/events/{id}", handler.NewHandler(app.HandleDeleteEvent, l))
+	r.Route("/api/v1", func(r chi.Router) {
+		r.Use(middleware.ContentTypeJson)
+
+		r.Method("GET", "/events", handler.NewHandler(app.HandleListEvents, l))
+		r.Method("POST", "/events", handler.NewHandler(app.HandleCreateEvent, l))
+		r.Method("GET", "/events/{id}", handler.NewHandler(app.HandleReadEvent, l))
+		r.Method("PUT", "/events/{id}", handler.NewHandler(app.HandleUpdateEvent, l))
+		r.Method("DELETE", "/events/{id}", handler.NewHandler(app.HandleDeleteEvent, l))
+	})
 
 	r.Method("GET", "/", handler.NewHandler(app.HandleIndex, l))
 


### PR DESCRIPTION
### What's Changed

Adding middleware to set the content type to JSON and updates route to `api/v1/` for events e.g. `http://localhost:8080/api/v1/events`.

### Technical Description

Adds a content type middleware to set the content type to `application/json` on the header of every request. 