### PR TITLE
Add CRUD implementation for Events endpoints

### DIFF
--- a/api/app/app.go
+++ b/api/app/app.go
@@ -7,8 +7,10 @@ import (
 )
 
 const (
+	appErrDataCreationFailure = "data creation failure"
 	appErrDataAccessFailure = "data access failure"
 	appErrJsonCreationFailure = "json creation failure"
+	appErrFormDecodingFailure = "form decoding failure"
 )
 
 type App struct{

--- a/api/app/app.go
+++ b/api/app/app.go
@@ -9,6 +9,7 @@ import (
 const (
 	appErrDataCreationFailure = "data creation failure"
 	appErrDataAccessFailure = "data access failure"
+	appErrDataUpdateFailure   = "data update failure"
 	appErrJsonCreationFailure = "json creation failure"
 	appErrFormDecodingFailure = "form decoding failure"
 )

--- a/api/app/event_handler.go
+++ b/api/app/event_handler.go
@@ -4,6 +4,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strconv"
+
+	"github.com/go-chi/chi"
+	"github.com/jinzhu/gorm"
 
 	"github.com/mergeforces/mergeforces-service/pkg/repository"
 )
@@ -38,8 +42,36 @@ func (app *App) HandleCreateEvent(w http.ResponseWriter, r *http.Request){
 }
 
 func (app *App) HandleReadEvent(w http.ResponseWriter, r *http.Request) {
-	w.WriteHeader(http.StatusOK)
-	w.Write([]byte("[]"))
+	id, err := strconv.ParseUint(chi.URLParam(r, "id"), 0, 64)
+	if err != nil || id == 0 {
+		app.logger.Info().Msgf("can not parse ID: %v", id)
+
+		w.WriteHeader(http.StatusUnprocessableEntity)
+		return
+	}
+
+	event, err := repository.ReadEvent(app.db, uint(id))
+	if err != nil {
+		if err == gorm.ErrRecordNotFound {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+
+		app.logger.Warn().Err(err).Msg("")
+
+		w.WriteHeader(http.StatusInternalServerError)
+		fmt.Fprintf(w, `{"error": "%v"}`, appErrDataAccessFailure)
+		return
+	}
+
+	dto := event.ToDto()
+	if err := json.NewEncoder(w).Encode(dto); err != nil {
+		app.logger.Warn().Err(err).Msg("")
+
+		w.WriteHeader(http.StatusInternalServerError)
+		fmt.Fprintf(w, `{"error": "%v"}`, appErrJsonCreationFailure)
+		return
+	}
 }
 
 func (app *App) HandleUpdateEvent(w http.ResponseWriter, r *http.Request) {

--- a/api/app/event_handler.go
+++ b/api/app/event_handler.go
@@ -107,5 +107,21 @@ func (app *App) HandleUpdateEvent(w http.ResponseWriter, r *http.Request) {
 }
 
 func (app *App) HandleDeleteEvent(w http.ResponseWriter, r *http.Request){
-	w.WriteHeader(http.StatusAccepted)
+	id, err := strconv.ParseUint(chi.URLParam(r, "id"), 0, 64)
+	if err != nil || id == 0 {
+		app.logger.Info().Msgf("can not parse ID: %v", id)
+
+		w.WriteHeader(http.StatusUnprocessableEntity)
+		return
+	}
+
+	if err := repository.DeleteEvent(app.db, uint(id)); err != nil {
+		app.logger.Warn().Err(err).Msg("")
+
+		w.WriteHeader(http.StatusInternalServerError)
+		fmt.Fprintf(w, `{"error": "%v"}`, appErrDataAccessFailure)
+		return
+	}
+
+	app.logger.Info().Msgf("Event deleted: %d", id)
 }

--- a/migrations/20191016221635_create_events_table.sql
+++ b/migrations/20191016221635_create_events_table.sql
@@ -2,7 +2,7 @@
 -- SQL in this section is executed when the migration is applied.
 CREATE TABLE IF NOT EXISTS events
 (
-    id             INT PRIMARY KEY,
+    id             SERIAL PRIMARY KEY,
     name           VARCHAR(255) NOT NULL,
     description    TEXT         NULL,
     location       VARCHAR(255) NOT NULL,

--- a/pkg/models/event.go
+++ b/pkg/models/event.go
@@ -1,8 +1,6 @@
 package models
 
 import (
-	"time"
-
 	"github.com/jinzhu/gorm"
 )
 
@@ -14,8 +12,6 @@ type Event struct {
 	Description  string
 	Location     string
 	Availability int
-	CreatedAt    time.Time
-	UpdatedAt    time.Time
 }
 
 type EventDtos []*EventDto
@@ -26,8 +22,22 @@ type EventDto struct {
 	Description  string `json:"description"`
 	Location     string `json:"location"`
 	Availability int    `json:"availability"`
-	CreatedAt    string `json:"created_at"`
-	UpdatedAt    string `json:"updated_at"`
+}
+
+type EventForm struct {
+	Name			string  `json:"name"`
+	Description		string  `json:"description"`
+	Location		string  `json:"location"`
+	Availability	int  	`json:"availability"`
+}
+
+func (f *EventForm) ToModel() (*Event, error) {
+	return &Event{
+		Name:			f.Name,
+		Description:	f.Description,
+		Location:		f.Location,
+		Availability:	f.Availability,
+	}, nil
 }
 
 func (e Event) ToDto() *EventDto {
@@ -37,8 +47,6 @@ func (e Event) ToDto() *EventDto {
 		Description:  e.Description,
 		Location:     e.Location,
 		Availability: e.Availability,
-		CreatedAt:    e.CreatedAt.Format("2006-01-02T15:04:05-07:00"),
-		UpdatedAt:    e.UpdatedAt.Format("2006-01-02T15:04:05-07:00"),
 	}
 }
 

--- a/pkg/repository/event.go
+++ b/pkg/repository/event.go
@@ -35,6 +35,14 @@ func ReadEvent(db *gorm.DB, id uint) (*models.Event, error) {
 	return event, nil
 }
 
+func UpdateEvent(db *gorm.DB, Event *models.Event) error {
+	if err := db.First(&models.Event{}, Event.ID).Update(Event).Error; err != nil {
+		return err
+	}
+
+	return nil
+}
+
 func DeleteEvent(db *gorm.DB, id uint) error {
 	event := &models.Event{}
 	if err := db.Where("id = ?", id).Delete(&event).Error; err != nil {

--- a/pkg/repository/event.go
+++ b/pkg/repository/event.go
@@ -18,3 +18,11 @@ func ListEvents(db *gorm.DB) (models.Events, error) {
 
 	return events, nil
 }
+
+func ReadEvent(db *gorm.DB, id uint) (*models.Event, error) {
+	event := &models.Event{}
+	if err := db.Where("id = ?", id).First(&event).Error; err != nil {
+		return nil, err
+	}
+	return event, nil
+}

--- a/pkg/repository/event.go
+++ b/pkg/repository/event.go
@@ -34,3 +34,12 @@ func ReadEvent(db *gorm.DB, id uint) (*models.Event, error) {
 	}
 	return event, nil
 }
+
+func DeleteEvent(db *gorm.DB, id uint) error {
+	event := &models.Event{}
+	if err := db.Where("id = ?", id).Delete(&event).Error; err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/pkg/repository/event.go
+++ b/pkg/repository/event.go
@@ -19,6 +19,14 @@ func ListEvents(db *gorm.DB) (models.Events, error) {
 	return events, nil
 }
 
+func CreateEvent(db *gorm.DB, event *models.Event) (*models.Event, error) {
+	if err := db.Create(event).Error; err != nil {
+		return nil, err
+	}
+
+	return event, nil
+}
+
 func ReadEvent(db *gorm.DB, id uint) (*models.Event, error) {
 	event := &models.Event{}
 	if err := db.Where("id = ?", id).First(&event).Error; err != nil {


### PR DESCRIPTION
### What's Changed

Implements CRUD for events endpoint

### Technical Description

Allows the Creation, Reading, Updating, and Deleting of endpoints via RESTful calls.

* Removes `created_at`, `updated_at`, and `deleted_at` as these fields are provided and managed by Gorm. 